### PR TITLE
[Tests] Security Error with jsdom > 11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-dom": "^15 || ^16"
   },
   "jest": {
+    "testEnvironment": "node",
     "setupFiles": [
       "./test/jestsetup.ts"
     ],


### PR DESCRIPTION
Got this error when testing:
`SecurityError: localStorage is not available for opaque origins`

Implemented solution: https://github.com/facebook/jest/issues/6766#issuecomment-408381957